### PR TITLE
Put XState service in context

### DIFF
--- a/packages/app/src/lib/contexts/app.ts
+++ b/packages/app/src/lib/contexts/app.ts
@@ -1,44 +1,25 @@
 import { appMachine } from '$lib/machines/appMachine';
-import { useMachine } from '@xstate/svelte';
 import { getContext, setContext } from 'svelte';
-import type { Readable } from 'svelte/store';
-import type {
-	EventFrom,
-	InterpreterFrom,
-	Sender,
-	StateFrom,
-	MachineOptions,
-	ContextFrom
-} from 'xstate';
+import type { EventFrom, InterpreterFrom, MachineOptions, ContextFrom } from 'xstate';
+import { interpret } from 'xstate';
 
 const AppContextSymbol = Symbol('AppContextSymbol');
 
 interface AppContext {
-	state: Readable<StateFrom<typeof appMachine>>;
-	send: Sender<EventFrom<typeof appMachine>>;
-	service: InterpreterFrom<typeof appMachine>;
+	appService: InterpreterFrom<typeof appMachine>;
 }
 
 export function useAppContextProvider(
 	config?: Partial<MachineOptions<ContextFrom<typeof appMachine>, EventFrom<typeof appMachine>>>
 ): AppContext {
-	const appContext = useMachine(appMachine, config);
+	const appService = interpret(appMachine.withConfig(config ?? {})).start();
+	const context: AppContext = {
+		appService
+	};
 
-	// To prevent issues where state machine would be stopped
-	// because the store has been unsubscribed by the previous page
-	// while going to another page, we keep a subscriber alive for
-	// all the navigation.
-	appContext.state.subscribe(({ value }) => {
-		console.log('state machine value', value);
-	});
+	setContext(AppContextSymbol, context);
 
-	appContext.service.onStop(() => {
-		console.log('machine stopped');
-	});
-
-	setContext(AppContextSymbol, appContext);
-
-	return appContext;
+	return context;
 }
 
 export function useAppContext(): AppContext {

--- a/packages/app/src/routes/confirmation-code.svelte
+++ b/packages/app/src/routes/confirmation-code.svelte
@@ -2,12 +2,12 @@
 	import AppLayout from '$lib/AppLayout.svelte';
 	import { useAppContext } from '$lib/contexts/app';
 
-	const { send } = useAppContext();
+	const { appService } = useAppContext();
 
 	let code: string = '';
 
 	function handleSubmit() {
-		send({
+		appService.send({
 			type: 'SELECT_CODE',
 			code
 		});

--- a/packages/app/src/routes/email.svelte
+++ b/packages/app/src/routes/email.svelte
@@ -2,12 +2,12 @@
 	import AppLayout from '$lib/AppLayout.svelte';
 	import { useAppContext } from '$lib/contexts/app';
 
-	const { send } = useAppContext();
+	const { appService } = useAppContext();
 
 	let emailAddress: string = '';
 
 	function handleSubmit() {
-		send({
+		appService.send({
 			type: 'SELECT_EMAIL',
 			email: emailAddress
 		});

--- a/packages/app/src/routes/index.svelte
+++ b/packages/app/src/routes/index.svelte
@@ -1,14 +1,17 @@
 <script lang="ts">
+	import { useSelector } from '@xstate/svelte';
 	import { fade } from 'svelte/transition';
 	import AppLayout from '$lib/AppLayout.svelte';
 	import { useAppContext } from '$lib/contexts/app';
 
-	const { state, send } = useAppContext();
-	$: hasSelectedFile = $state.matches('selectedFile');
+	const { appService } = useAppContext();
+
+	const hasSelectedFile = useSelector(appService, (state) => state.matches('selectedFile'));
+	const isSelectingFile = useSelector(appService, (state) => state.matches('selectingFile'));
 
 	let documentInput: HTMLInputElement | undefined;
 	$: {
-		if ($state.matches('selectingFile') && documentInput !== undefined) {
+		if ($isSelectingFile === true && documentInput !== undefined) {
 			documentInput.value = '';
 		}
 	}
@@ -30,20 +33,20 @@
 			return;
 		}
 
-		send({
+		appService.send({
 			type: 'SELECT_FILE',
 			file: firstFile
 		});
 	}
 
 	function handleCreateProcedureClick() {
-		send({
+		appService.send({
 			type: 'CREATE_PROCEDURE'
 		});
 	}
 
 	function handleCancelProcedureClick() {
-		send({
+		appService.send({
 			type: 'CANCEL_PROCEDURE_CREATION'
 		});
 	}
@@ -93,7 +96,7 @@
 			</div>
 		</div>
 
-		{#if hasSelectedFile}
+		{#if $hasSelectedFile === true}
 			<div
 				transition:fade={{ duration: 200 }}
 				class="flex items-center p-4 mt-4 space-x-2 border border-gray-200 rounded-md"

--- a/packages/app/src/routes/signature-validated.svelte
+++ b/packages/app/src/routes/signature-validated.svelte
@@ -1,18 +1,19 @@
 <script lang="ts">
+	import { useSelector } from '@xstate/svelte';
 	import AppLayout from '$lib/AppLayout.svelte';
 	import { useAppContext } from '$lib/contexts/app';
 	import PdfViewer from '$lib/PdfViewer.svelte';
 
-	const { state } = useAppContext();
-
-	$: documentURL = $state.context.documentPresignedURL;
+	const { appService } = useAppContext();
+	
+	const documentURL = useSelector(appService, (state) => state.context.documentPresignedURL);
 </script>
 
 <AppLayout title="Signature validated">
 	<div class="mt-2 flex flex-col flex-grow">
-		{#if documentURL}
+		{#if $documentURL !== undefined}
 			<div class="flex-grow grid grid-cols-1 grid-rows-1">
-				<PdfViewer url={documentURL} title="Signed document" />
+				<PdfViewer url={$documentURL} title="Signed document" />
 			</div>
 		{/if}
 	</div>

--- a/packages/app/src/routes/viewer.svelte
+++ b/packages/app/src/routes/viewer.svelte
@@ -1,20 +1,21 @@
 <script lang="ts">
+	import { useSelector } from '@xstate/svelte';
 	import AppLayout from '$lib/AppLayout.svelte';
 	import { useAppContext } from '$lib/contexts/app';
 	import PdfViewer from '$lib/PdfViewer.svelte';
 
-	const { state, send } = useAppContext();
+	const { appService } = useAppContext();
 
-	$: documentURL = $state.context.documentPresignedURL;
+	const documentURL = useSelector(appService, (state) => state.context.documentPresignedURL);
 
 	function handleCancelProcedureClick() {
-		send({
+		appService.send({
 			type: 'CANCEL_SIGNATURE'
 		});
 	}
 
 	function handleConfirmProcedureClick() {
-		send({
+		appService.send({
 			type: 'CONFIRM_SIGNATURE'
 		});
 	}
@@ -22,9 +23,9 @@
 
 <AppLayout title="Sign document">
 	<div class="mt-2 flex flex-col flex-grow">
-		{#if documentURL}
+		{#if $documentURL !== undefined}
 			<div class="flex-grow grid grid-cols-1 grid-rows-1">
-				<PdfViewer url={documentURL} title="Document to sign" />
+				<PdfViewer url={$documentURL} title="Document to sign" />
 			</div>
 		{/if}
 


### PR DESCRIPTION
We should not use`useMachine` to provide an invoked state machine in a context. `useMachine` spawns a machine in a component and kills it when the component unmounts.

Instead we need to follow the following pattern:
- Provide the service in the context
- Send events to the service by calling `send` function from the service
- Use [`useSelector`](https://xstate.js.org/docs/packages/xstate-svelte/#api) to extract some data from the current state